### PR TITLE
Add web manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "Lilou Logistique",
+  "short_name": "Lilou",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "logo.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "logo.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
 import { analyzer } from 'vite-bundle-analyzer'
+import manifest from './manifest.json' assert { type: 'json' }
 
 export default defineConfig(({ mode }) => ({
   plugins: [
@@ -23,19 +24,7 @@ export default defineConfig(({ mode }) => ({
           }
         ]
       },
-      manifest: {
-        name: 'Lilou Logistique',
-        short_name: 'Lilou',
-        description: 'Logistics Management System',
-        theme_color: '#ffffff',
-        icons: [
-          {
-            src: 'logo.png',
-            sizes: '192x192',
-            type: 'image/png'
-          }
-        ]
-      }
+      manifest
     }),
     mode === 'analyze' && analyzer()
   ].filter(Boolean),


### PR DESCRIPTION
## Summary
- add `manifest.json` describing app name and icons
- load the manifest in `vite.config.ts`

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68694dd3b4c4832dba6df74ace211d38