### PR TITLE
Use GitHub secrets for Hostinger workflow

### DIFF
--- a/.github/workflows/deploy-hostinger.yml
+++ b/.github/workflows/deploy-hostinger.yml
@@ -50,9 +50,9 @@ jobs:
           NEXT_PUBLIC_APP_NAME: 'Lilou Logistique DSP'
           NEXT_PUBLIC_APP_VERSION: '1.0.0'
           NEXT_PUBLIC_APP_URL: 'https://lilou-logistique.com'
-          NEXT_PUBLIC_SUPABASE_URL: https://mvhogfelpbufnrklxpxq.supabase.co
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im12aG9nZmVscGJ1Zm5ya2x4cHhxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg3MjQ0MDksImV4cCI6MjA2NDMwMDQwOX0.FrVdKelHzLgJFGFwnYfA23XsbzgrK6PCsSV01a1qM5I
-          OPENAI_API_KEY: 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
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: npm run build
 
       - name: 📁 Préparation des fichiers de déploiement

--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ cp .env.example .env.local
 | `OPENAI_API_KEY`                ||
 | `JWT_SECRET`                    |                      |
 | `NEXTAUTH_SECRET`               |                |
+### Ajouter les secrets GitHub
+
+Pour permettre le déploiement automatique, ajoutez aussi ces variables dans
+**Settings → Secrets and variables → Actions** de votre dépôt GitHub :
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `OPENAI_API_KEY`
+
 
 ---
 


### PR DESCRIPTION
## Summary
- reference repository secrets in the Hostinger deployment workflow
- document how to configure these secrets in GitHub

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_b_686a94d13aec832db69e02736de5e7f1