### PR TITLE
Update GH actions to v4

### DIFF
--- a/.github/workflows/deploy-hostinger.yml
+++ b/.github/workflows/deploy-hostinger.yml
@@ -15,10 +15,10 @@ jobs:
     
     steps:
       - name: 📥 Checkout du code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 📦 Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -140,7 +140,7 @@ jobs:
           echo "Commit: ${{ github.sha }}" >> hostinger-deploy/deploy-info.txt
 
       - name: 📤 Upload des artefacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: hostinger-files
           path: hostinger-deploy/
@@ -170,7 +170,7 @@ jobs:
     
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary
- update `actions/checkout`, `actions/setup-node` and `actions/upload-artifact` to `v4` in the Hostinger deployment workflow

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_b_686aae1473bc832db8862504db671411