### PR TITLE
Replace placeholder main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,1 +1,39 @@
+name: CI
 
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+
+env:
+  NODE_VERSION: '20'
+  FORCE_COLOR: 1
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint --if-present
+
+      - name: Type check
+        run: npm run type-check --if-present
+
+      - name: Run tests
+        run: npm run test --if-present
+
+      - name: Build
+        run: npm run build --if-present


### PR DESCRIPTION
## Summary
- add a real GitHub Actions workflow to run basic CI tasks

## Testing
- `npm run test` *(fails: no tests found)*
- `npm run validate-env` *(fails: `.env.local` missing)*
- `npm run build` *(fails: failed to fetch `Inter` font due to network access restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_686aae1389ec832d8d8271a515dc6b4b