### PR TITLE
Enable strict mode in shell scripts

### DIFF
--- a/init-github.sh
+++ b/init-github.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Script d'initialisation GitHub pour Lilou Logistique
 # Usage: bash init-github.sh

--- a/scripts/build-static.sh
+++ b/scripts/build-static.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Script pour générer une version statique de l'application
 # Compatible avec l'hébergement mutualisé Hostinger

--- a/scripts/create-deploy-branch.sh
+++ b/scripts/create-deploy-branch.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Script pour créer la branche hostinger-deploy rapidement
 # Utile pour le premier déploiement sur Hostinger


### PR DESCRIPTION
## Summary
- enforce `set -euo pipefail` at the top of shell scripts

## Testing
- `npm test`
- `bash -n scripts/build-static.sh`
- `bash -n scripts/create-deploy-branch.sh`
- `bash -n init-github.sh`


------
https://chatgpt.com/codex/tasks/task_b_686ad0a0cb9c832d8eff695b154b4ff1