### PR TITLE
fix: normalize script encoding

### DIFF
--- a/scripts/build-static.sh
+++ b/scripts/build-static.sh
@@ -90,4 +90,4 @@ RewriteRule ^(.*)$ /index.html [L]
 EOF
 
 echo "✅ Build statique terminé ! Les fichiers sont dans le dossier 'deploy/'"
-echo "📁 Ces fichiers peuvent être déployés sur l'hébergement mutualisé Hostinger"
+echo "📁 Ces fichiers peuvent être déployés sur l'hébergement mutualisé Hostinger."


### PR DESCRIPTION
## Summary
- replace garbled line in `build-static.sh`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686ad51996ec832dabca05e7f5270c1c