### PR TITLE
Add unit tests for env validation and pages

### DIFF
--- a/__tests__/home.test.tsx
+++ b/__tests__/home.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react'
+import Home from '../app/page'
+
+describe('Home page', () => {
+  it('renders main heading', () => {
+    render(<Home />)
+    expect(screen.getByText('🚚 Lilou Logistique')).toBeInTheDocument()
+  })
+})

--- a/__tests__/layout.test.tsx
+++ b/__tests__/layout.test.tsx
@@ -1,0 +1,17 @@
+/**
+ * @jest-environment node
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import RootLayout from '../app/layout'
+
+describe('RootLayout', () => {
+  it('renders children and html structure', () => {
+    const markup = renderToStaticMarkup(
+      <RootLayout>
+        <div data-testid="child" />
+      </RootLayout>
+    )
+    expect(markup).toContain('data-testid="child"')
+    expect(markup).toContain('<html lang="fr"')
+  })
+})

--- a/__tests__/validate-env.test.ts
+++ b/__tests__/validate-env.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment node
+ */
+import { spawnSync } from 'child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import path from 'path';
+import os from 'os';
+
+const scriptPath = path.resolve(__dirname, '../scripts/validate-env.js');
+
+function runScript(dir: string) {
+  return spawnSync('node', [scriptPath], { cwd: dir, encoding: 'utf-8' });
+}
+
+function createEnvFile(dir: string, content: string) {
+  writeFileSync(path.join(dir, '.env.local'), content);
+}
+
+describe('validate-env script', () => {
+  test('exits with code 1 if .env.local is missing', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'envtest-'));
+    const result = runScript(dir);
+    rmSync(dir, { recursive: true, force: true });
+    expect(result.status).toBe(1);
+  });
+
+  test('succeeds when all required variables are present', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'envtest-'));
+    createEnvFile(
+      dir,
+      `NEXT_PUBLIC_SUPABASE_URL=https://project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=anon
+SUPABASE_SERVICE_ROLE_KEY=service
+OPENAI_API_KEY=openai
+JWT_SECRET=abcdefghijklmnopqrstuvwxyz123456
+NEXTAUTH_SECRET=abcdefghijklmnopqrstuvwxyz654321
+`
+    );
+    const result = runScript(dir);
+    rmSync(dir, { recursive: true, force: true });
+    expect(result.status).toBe(0);
+    expect(result.stdout + result.stderr).toMatch(/Validation/);
+  });
+
+  test('exits with code 1 when a required variable is missing', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'envtest-'));
+    createEnvFile(
+      dir,
+      `NEXT_PUBLIC_SUPABASE_URL=https://project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=anon
+SUPABASE_SERVICE_ROLE_KEY=service
+OPENAI_API_KEY=openai
+JWT_SECRET=abcdefghijklmnopqrstuvwxyz123456
+`
+    );
+    const result = runScript(dir);
+    rmSync(dir, { recursive: true, force: true });
+    expect(result.status).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add jest tests for `scripts/validate-env.js`
- test RootLayout markup
- test Home page rendering

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_686ae5899774832d9d390d2cb369a003