### PR TITLE
Allow custom repo in Hostinger installer

### DIFF
--- a/GUIDE_RAPIDE_HOSTINGER.md
+++ b/GUIDE_RAPIDE_HOSTINGER.md
@@ -13,7 +13,10 @@
    ```bash
    wget https://raw.githubusercontent.com/Lilou2023/lilou-logistique/main/scripts/install-hostinger.sh
    chmod +x install-hostinger.sh
-   sudo ./install-hostinger.sh
+   # Optionnel : passez votre URL Git en argument ou via REPO_URL
+   sudo ./install-hostinger.sh [votre-repo.git]
+   # ou
+   REPO_URL=[votre-repo.git] sudo ./install-hostinger.sh
    ```
 
 3. **Configurez vos variables d'environnement**

--- a/scripts/install-hostinger.sh
+++ b/scripts/install-hostinger.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 # Script d'installation automatique pour Lilou Logistique sur Hostinger VPS
-# Usage: bash install-hostinger.sh
+# Usage: bash install-hostinger.sh [REPO_URL]
+# Vous pouvez aussi définir la variable d'environnement REPO_URL pour
+# personnaliser le dépôt à cloner. Par défaut, le script utilise le dépôt
+# officiel.
 
 set -e
 
@@ -11,7 +14,10 @@ echo "================================================"
 
 # Variables
 APP_DIR="/var/www/lilou-logistique"
-REPO_URL="https://github.com/Lilou2023/lilou-logistique.git"
+# URL du repository Git à cloner
+REPO_URL_DEFAULT="https://github.com/Lilou2023/lilou-logistique.git"
+# Priorité : variable d'environnement puis argument, sinon valeur par défaut
+REPO_URL="${REPO_URL:-${1:-$REPO_URL_DEFAULT}}"
 DOMAIN=""
 EMAIL=""
 


### PR DESCRIPTION
## Summary
- allow overriding `REPO_URL` in Hostinger install script
- document custom repo usage in quick start guide

## Testing
- `npm test`
- `REPO_URL="https://example.com/foo.git" bash -x scripts/install-hostinger.sh | head -n 20`

------
https://chatgpt.com/codex/tasks/task_b_686ae47d4218832d8721ee4fa1df9f4a