### PR TITLE
Add cleanup trap to build script

### DIFF
--- a/scripts/build-static.sh
+++ b/scripts/build-static.sh
@@ -26,6 +26,9 @@ const nextConfig = {
 module.exports = nextConfig
 EOF
 
+# S'assurer que la configuration d'origine est restaurée en cas d'interruption
+trap 'if [[ -f next.config.js.bak ]]; then mv next.config.js.bak next.config.js; fi' EXIT
+
 # Remplacer temporairement la config
 mv next.config.js next.config.js.bak
 mv next.config.static.js next.config.js


### PR DESCRIPTION
## Summary
- ensure original Next.js config restores if build script exits early

## Testing
- `npm test`
- ran modified `build-static.sh` with a simulated failure to confirm restoration

------
https://chatgpt.com/codex/tasks/task_b_686ae47b4758832db64343af41a31f9f