### PR TITLE
chore: update actions to v4

### DIFF
--- a/.github/workflows/deploy-hostinger.yml
+++ b/.github/workflows/deploy-hostinger.yml
@@ -175,7 +175,7 @@ jobs:
           fetch-depth: 0
 
       - name: 📥 Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: hostinger-files
           path: hostinger-deploy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'

--- a/.github/workflows/validate-env.yml
+++ b/.github/workflows/validate-env.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: 📥 Checkout du code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 📦 Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -63,10 +63,10 @@ jobs:
     name: 🔒 Audit Sécurité
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: 🔧 Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'


### PR DESCRIPTION
## Summary
- update GitHub actions to use v4 versions of checkout, setup-node and download-artifact

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_686aeaa09150832d9b8d27c74c42f253