### PR TITLE
Add comprehensive unit tests

### DIFF
--- a/__tests__/home.test.tsx
+++ b/__tests__/home.test.tsx
@@ -6,4 +6,11 @@ describe('Home page', () => {
     render(<Home />)
     expect(screen.getByText('🚚 Lilou Logistique')).toBeInTheDocument()
   })
+
+  it('displays feature sections', () => {
+    render(<Home />)
+    expect(screen.getByText('🔐 Sécurisé')).toBeInTheDocument()
+    expect(screen.getByText('⚡ Temps Réel')).toBeInTheDocument()
+    expect(screen.getByText('🤖 Intelligent')).toBeInTheDocument()
+  })
 })

--- a/__tests__/validate-env.test.ts
+++ b/__tests__/validate-env.test.ts
@@ -79,4 +79,60 @@ NEXTAUTH_SECRET=abcdefghijklmnopqrstuvwxyz654321
     expect(result.status).toBe(0);
     expect(result.stdout + result.stderr).toMatch(/avertissements/i);
   });
+
+  test('warns when a .env file exists', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'envtest-'));
+    createEnvFile(
+      dir,
+      `NEXT_PUBLIC_SUPABASE_URL=https://project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=anon
+SUPABASE_SERVICE_ROLE_KEY=service
+OPENAI_API_KEY=openai
+JWT_SECRET=abcdefghijklmnopqrstuvwxyz123456
+NEXTAUTH_SECRET=abcdefghijklmnopqrstuvwxyz654321
+`
+    );
+    // create a .env file to trigger warning
+    writeFileSync(path.join(dir, '.env'), 'DUMMY=1');
+    const result = runScript(dir);
+    rmSync(dir, { recursive: true, force: true });
+    expect(result.status).toBe(0);
+    expect(result.stdout + result.stderr).toMatch(/Un fichier \.env existe/);
+  });
+
+  test('warns on invalid Supabase URL', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'envtest-'));
+    createEnvFile(
+      dir,
+      `NEXT_PUBLIC_SUPABASE_URL=https://example.com
+NEXT_PUBLIC_SUPABASE_ANON_KEY=anon
+SUPABASE_SERVICE_ROLE_KEY=service
+OPENAI_API_KEY=openai
+JWT_SECRET=abcdefghijklmnopqrstuvwxyz123456
+NEXTAUTH_SECRET=abcdefghijklmnopqrstuvwxyz654321
+`
+    );
+    const result = runScript(dir);
+    rmSync(dir, { recursive: true, force: true });
+    expect(result.status).toBe(0);
+    expect(result.stdout + result.stderr).toMatch(/ne semble pas être une URL Supabase valide/);
+  });
+
+  test('warns when secrets are too short', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'envtest-'));
+    createEnvFile(
+      dir,
+      `NEXT_PUBLIC_SUPABASE_URL=https://project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=anon
+SUPABASE_SERVICE_ROLE_KEY=service
+OPENAI_API_KEY=openai
+JWT_SECRET=short
+NEXTAUTH_SECRET=shorter
+`
+    );
+    const result = runScript(dir);
+    rmSync(dir, { recursive: true, force: true });
+    expect(result.status).toBe(0);
+    expect(result.stdout + result.stderr).toMatch(/au moins 32 caractères/);
+  });
 });


### PR DESCRIPTION
## Summary
- expand home page tests
- cover more cases in `validate-env` script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686b1e5f57b4832d86c365451f5856f9