### PR TITLE
Add custom not-found page

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,10 @@
+export default function NotFound() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-24">
+      <h1 className="text-3xl font-bold mb-4">Oups ! Page introuvable</h1>
+      <p className="text-center text-gray-600 dark:text-gray-400">
+        Désolé, cette page n’existe pas ou plus.
+      </p>
+    </main>
+  )
+}

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,10 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
+
+  // Lors de l'export statique, inclure un slash final pour que
+  // la page `not-found` soit correctement générée en `404/index.html`
+  trailingSlash: true,
   
   // Configuration des images
   images: {


### PR DESCRIPTION
## Summary
- create `app/not-found.tsx` with a friendly 404 message
- configure `next.config.js` with `trailingSlash` so export generates `404/index.html`

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_b_686be74562fc832d81a39d9481f2c405