### PR TITLE
Add AppInfo component unit test

### DIFF
--- a/src/__tests__/AppInfo.test.tsx
+++ b/src/__tests__/AppInfo.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import AppInfo from '../components/AppInfo';
+
+describe('AppInfo', () => {
+  it('renders name and version', () => {
+    process.env.NEXT_PUBLIC_APP_NAME = 'Test App';
+    process.env.NEXT_PUBLIC_APP_VERSION = '0.1.0';
+
+    render(<AppInfo />);
+
+    expect(screen.getByText('Test App')).toBeInTheDocument();
+    expect(screen.getByText('v0.1.0')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add basic unit test for AppInfo

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_686be741f0a4832db368bc61856b7d95