### PR TITLE
Fix Next.js config for Vercel

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,8 +3,7 @@ const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
   
-  // Configuration pour l'export statique
-  output: 'export',
+  // Configuration standard pour Vercel
   trailingSlash: true,
   
   // Configuration des images


### PR DESCRIPTION
## Summary
- remove static export setting in `next.config.js`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_686c5a0cfd08832d8de6e27ec2561fd6