### PR TITLE
Update build docs and ignore conflict backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ logs
 
 # Hostinger deployment
 public_html/
+*.orig

--- a/GUIDE_DEMARRAGE_RAPIDE.md
+++ b/GUIDE_DEMARRAGE_RAPIDE.md
@@ -131,7 +131,7 @@ npm run validate-env
 
 ```bash
 # Build statique pour Hostinger
-npm run build:hostinger
+npm run build
 
 # Vérifier les fichiers générés
 ls out/
@@ -183,7 +183,7 @@ npm run test:coverage # Tests avec couverture
 ### Déploiement
 
 ```bash
-npm run build:hostinger  # Build pour Hostinger
+npm run build  # Build pour Hostinger
 npm run deploy          # Déploiement manuel
 ```
 

--- a/docs/POST_MERGE_CHECKLIST.md
+++ b/docs/POST_MERGE_CHECKLIST.md
@@ -17,7 +17,7 @@ Ce document aide à ne rien oublier juste après la fusion d'une branche importa
 
 - [ ] Exécuter la commande :
   ```bash
-  npm run build:hostinger
+  npm run build
   ```
 - [ ] Vérifier que le dossier `/out` a été généré
 - [ ] Copier le contenu vers la racine de `hostinger-deploy`

--- a/docs/README_DEPLOIEMENT.md
+++ b/docs/README_DEPLOIEMENT.md
@@ -30,7 +30,7 @@ git merge main
 
 # Rebuild + export statique
 npm install
-npm run build:hostinger
+npm run build
 cp -r out/* .
 
 # Commit et push

--- a/temp_files/GUIDE_DEMARRAGE_RAPIDE.md
+++ b/temp_files/GUIDE_DEMARRAGE_RAPIDE.md
@@ -131,7 +131,7 @@ npm run validate-env
 
 ```bash
 # Build statique pour Hostinger
-npm run build:hostinger
+npm run build
 
 # Vérifier les fichiers générés
 ls out/
@@ -183,7 +183,7 @@ npm run test:coverage # Tests avec couverture
 ### Déploiement
 
 ```bash
-npm run build:hostinger  # Build pour Hostinger
+npm run build  # Build pour Hostinger
 npm run deploy          # Déploiement manuel
 ```
 


### PR DESCRIPTION
## Summary
- update docs to use `npm run build`
- ignore `.orig` conflict files

## Testing
- `npm run test` *(fails: No tests found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686c56ea0598832da354bbf323673f62