### PR TITLE
Fix export line in next.config.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,7 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
-  
+
   // Configuration des images
   images: {
     domains: [
@@ -48,5 +48,4 @@ const nextConfig = {
     ]
   },
 }
-
-module.exports = nextConfig
+module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- fix erroneous export line in `next.config.js`
- clean up trailing whitespace

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_b_686bd8aa7d18832dadd05a864e74be68