### PR TITLE
Fix vercel runtime

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,7 +7,7 @@
   "regions": ["cdg1"],
   "functions": {
     "app/api/**/*.ts": {
-      "runtime": "nodejs18.x"
+      "runtime": "nodejs20.x"
     }
   },
   "headers": [
@@ -28,5 +28,4 @@
         }
       ]
     }
-  ]
-} 
+  ]} 


### PR DESCRIPTION
## Summary
- set node runtime to 20.x in vercel.json

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686d6b306b44832d9ee64b023af2952e